### PR TITLE
Removing misleading sentence "Note the column that serves as a groupi…

### DIFF
--- a/topics/02_Controls/igGrid/03_Features/00_Columns/01_Grouping/00_igGrid_GroupBy_Overview.md
+++ b/topics/02_Controls/igGrid/03_Features/00_Columns/01_Grouping/00_igGrid_GroupBy_Overview.md
@@ -29,7 +29,7 @@ This topic contains the following sections:
 
 ## <a id="introduction"></a> Introduction
 
-The `igGrid` supports a column grouping functionality that enables the user to employ the data in one or more columns in a grid as a primary and, respectively, secondary criteria for organizing the records in the group in groups. The picture bellow demonstrate a grid in which the values of the `SafetyStockLevel` column – 500, 8000, 1,000, etc. – are used to group and arrange the data in the grid, i.e. the grid is grouped by its `SafetyStockLevel` column. Note the column that serves as a grouping criterion is taken out of the grid.
+The `igGrid` supports a column grouping functionality that enables the user to employ the data in one or more columns in a grid as a primary and, respectively, secondary criteria for organizing the records in the group in groups. The picture bellow demonstrate a grid in which the values of the `SafetyStockLevel` column – 500, 8000, 1,000, etc. – are used to group and arrange the data in the grid, i.e. the grid is grouped by its `SafetyStockLevel` column. 
 
 ![](images/igGrid_GroupBy_Overview_01.png)
 


### PR DESCRIPTION
…ng criterion is taken out of the grid." in "Column Grouping Overview (i

Removing misleading sentence "Note the column that serves as a grouping
criterion is taken out of the grid." in "Column Grouping Overview (i
