### PR TITLE
Update 00_igGrid_Binding_to_HTML_Table_Data.md

### DIFF
--- a/topics/02_Controls/igGrid/02_Binding/Client-Side/00_igGrid_Binding_to_HTML_Table_Data.md
+++ b/topics/02_Controls/igGrid/02_Binding/Client-Side/00_igGrid_Binding_to_HTML_Table_Data.md
@@ -23,7 +23,7 @@ The Ignite UI® `igGrid`, allows binding to existing plain HTML tables, through 
 **In Javascript:**
 
 ```js
-dataSource: $(‘#myTable’)[0]
+dataSource: $('#myTable')[0]
 ```
 
 > **Note:** the indexer is needed in order to select the DOM element containing the data.


### PR DESCRIPTION
If the code `"$(‘#myTable’)[0]"` is copied and pasted to a notepad, the single quotes are recognized as multi-byte character.
