### PR TITLE
Issue #380: FIXED - Typo in Ignite UI CLI documentation

### DIFF
--- a/topics/01_General-and-Getting-Started/17_Using_Ignite_UI_CLI.md
+++ b/topics/01_General-and-Getting-Started/17_Using_Ignite_UI_CLI.md
@@ -137,5 +137,5 @@ The command takes in a single search term and opens the Infragistics search in t
 To list all the Ignite UI CLI available commands, execute the following command:
 
 ```
-    ng help
+    ig help
 ```


### PR DESCRIPTION
Documentation accidentally listed the Angular CLI help command as the Ignite UI CLI help command.